### PR TITLE
adding CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @berryhq/admin


### PR DESCRIPTION
Declare admin team as code owners, so we can enable mandatory PR approval by one of them.

No code changes.